### PR TITLE
Increased performance of ReadString methods by avoiding read unnecessary data

### DIFF
--- a/src/AslHelp.Memory/Ipc/ProcessMemory/Read/ProcessMemory.ReadString.cs
+++ b/src/AslHelp.Memory/Ipc/ProcessMemory/Read/ProcessMemory.ReadString.cs
@@ -58,7 +58,7 @@ public partial class ProcessMemory
             ? stackalloc sbyte[1024]
             : (rented = ArrayPool<sbyte>.Shared.Rent(maxLength));
 
-        ReadArray(buffer, baseAddress, offsets);
+        ReadArray(buffer[..maxLength], baseAddress, offsets);
 
         string result = GetStringFromSByteSpan(buffer[..maxLength]);
 
@@ -74,7 +74,7 @@ public partial class ProcessMemory
             ? stackalloc char[512]
             : (rented = ArrayPool<char>.Shared.Rent(maxLength));
 
-        ReadArray(buffer, baseAddress, offsets);
+        ReadArray(buffer[..maxLength], baseAddress, offsets);
 
         string result = GetStringFromCharSpan(buffer);
 
@@ -91,7 +91,7 @@ public partial class ProcessMemory
             ? stackalloc byte[1024]
             : (rented = ArrayPool<byte>.Shared.Rent(maxLength * 2));
 
-        ReadArray(buffer, baseAddress, offsets);
+        ReadArray(buffer[..(maxLength * 2)], baseAddress, offsets);
 
         string result;
         if (maxLength >= 2 && buffer is [> 0, 0, > 0, 0, ..]) // Best assumption we can make.


### PR DESCRIPTION
This commit reduces the size of the Span buffer used to store the data read from memory to the amount required myu the method call. This avoids reading the entire span when unnecessary and resulta into reading a lower amount of data from memory, increasing performance.

As of now, reading any string with a total byte size lower than 1024 would still result into reading 1024 bytes. This feels unnecessary as it also results into a (small) performance impact.